### PR TITLE
Add ability to escape strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 Send content from the current Neovim buffer to a configurable tmux pane.
 
-[![asciicast](https://asciinema.org/a/MqKy1l509Y5fLuBtTpXaRkQAI.png)](https://asciinema.org/a/MqKy1l509Y5fLuBtTpXaRkQAI)
-
 ## Example setup and (installation)
 Via [lazy](https://github.com/folke/lazy.nvim):
 ```lua
@@ -29,6 +27,12 @@ The target pane that text is sent to follows the standard `send-keys` format, so
 ```
 :lua require('slimux').configure_target_pane('0.1')
 ```
+
+Additionally, some effort is taken to automatically smart-escape input to send it to its destination intact. The array of escaped strings can be overridden in the above setup function, with the default setting being the below:
+```
+escaped_strings = { '\\', ';', '"', '\'' }
+```
+
 For more detail on specifying tmux command targets, check out the documentation included with the project: https://github.com/tmux/tmux/wiki/Advanced-Use#command-targets
 
 Also, a reminder that pane numbers can be shown via `prefix + q`, which in a standard install will be `C-b + q`.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The target pane that text is sent to follows the standard `send-keys` format, so
 :lua require('slimux').configure_target_pane('0.1')
 ```
 
-Additionally, some effort is taken to automatically smart-escape input to send it to its destination intact. The array of escaped strings can be overridden in the above setup function, with the default setting being the below:
+Additionally, some effort is taken to automatically escape input to send it to its destination intact. The array of escaped strings can be overridden in the above setup function, with the default setting being the below:
 ```
 escaped_strings = { '\\', ';', '"', '\'' }
 ```

--- a/lua/slimux/init.lua
+++ b/lua/slimux/init.lua
@@ -2,7 +2,7 @@ local M = {}
 
 M.__target_socket = ""
 M.__target_pane = ""
-M.__escaped_strings = { '\\', ';', '"', '\'' }
+M.__escaped_strings = { '\\', ';', '"', '$', '\'' }
 
 function M.setup(config)
 	M.__target_socket = config.target_socket
@@ -72,11 +72,14 @@ function M.__capture_paragraph_text()
 end
 
 function M.__escape(text)
-	local escaped = text
-	for _, char in ipairs(M.__escaped_chars) do
-		escaped = string.gsub(escaped, char, "\\" .. char)
+	local escapedString = text
+	for _, substring in ipairs(M.__escaped_strings) do
+		local escapedSubstring = string.gsub(substring, "[%(%)%.%%%+%-%*%?%[%]%^%$]", "%%%1")
+		escapedString = string.gsub(escapedString, escapedSubstring, function(match)
+			return "\\" .. match
+		end)
 	end
-	return escaped
+	return escapedString
 end
 
 function M.__send(text)

--- a/lua/slimux/init.lua
+++ b/lua/slimux/init.lua
@@ -1,15 +1,19 @@
 local M = {}
 
-M.__target_socket = ''
-M.__target_pane = ''
+M.__target_socket = ""
+M.__target_pane = ""
+M.__escaped_strings = { '\\', ';', '"', '\'' }
 
 function M.setup(config)
 	M.__target_socket = config.target_socket
 	M.__target_pane = config.target_pane
+	if config.escaped_strings ~= nil then
+		M.__escaped_strings = config.escaped_strings
+	end
 end
 
 function M.get_tmux_socket()
-	local tmux = vim.env.TMUX ~= nil and vim.env.TMUX or ''
+	local tmux = vim.env.TMUX ~= nil and vim.env.TMUX or ""
 	local socket = vim.split(tmux, ",")[1]
 	return socket
 end
@@ -19,23 +23,27 @@ function M.get_tmux_window()
 end
 
 function M.print_config()
-	vim.print(string.format('socket: %s, pane: %s', M.__target_socket, M.__target_pane))
+	vim.print(string.format("socket: %s, pane: %s", M.__target_socket, M.__target_pane))
 end
 
-function M.configure_target_socket(name)
-	M.__target_socket = name
+function M.configure_target_socket(socket)
+	M.__target_socket = socket
 end
 
-function M.configure_target_pane(name)
-	M.__target_pane = name
+function M.configure_target_pane(pane)
+	M.__target_pane = pane
+end
+
+function M.configure_escape_strings(strings)
+	M.__escaped_strings = strings
 end
 
 function M.__capture_highlighted_text()
 	local current_buffer = vim.api.nvim_get_current_buf()
-	local start_line, _ = unpack(vim.api.nvim_buf_get_mark(current_buffer, '<'))
-	local end_line, _ = unpack(vim.api.nvim_buf_get_mark(current_buffer, '>'))
+	local start_line, _ = unpack(vim.api.nvim_buf_get_mark(current_buffer, "<"))
+	local end_line, _ = unpack(vim.api.nvim_buf_get_mark(current_buffer, ">"))
 	local highlighted_text = vim.api.nvim_buf_get_lines(current_buffer, start_line - 1, end_line, false)
-	highlighted_text = table.concat(highlighted_text, '\n')
+	highlighted_text = table.concat(highlighted_text, "\n")
 	return highlighted_text
 end
 
@@ -59,27 +67,28 @@ function M.__capture_paragraph_text()
 		end_line = end_line + 1
 	end
 	local paragraph_lines = vim.api.nvim_buf_get_lines(current_buffer, start_line, end_line, false)
-	local paragraph_text = table.concat(paragraph_lines, '\n')
+	local paragraph_text = table.concat(paragraph_lines, "\n")
 	return paragraph_text
 end
 
-function M.__escape_trailing_semicolons(text)
-	local escaped = string.gsub(text, ';\n', '\\;\n')
-	if string.sub(escaped, -1) == ';' then
-		escaped = string.sub(escaped, 1, -2) .. '\\;'
+function M.__escape(text)
+	local escaped = text
+	for _, char in ipairs(M.__escaped_chars) do
+		escaped = string.gsub(escaped, char, "\\" .. char)
 	end
 	return escaped
 end
 
 function M.__send(text)
-	text = M.__escape_trailing_semicolons(text)
+	text = M.__escape(text)
 	local flag
-	if string.sub(M.__target_socket, 1, 1) == '/' then
-		flag = 'S'
+	if string.sub(M.__target_socket, 1, 1) == "/" then
+		flag = "S"
 	else
-		flag = 'L'
+		flag = "L"
 	end
-	local cmd = string.format('tmux -%s %s send-keys -t %s -- "%s" Enter', flag, M.__target_socket, M.__target_pane, text)
+	local cmd = string.format('tmux -%s %s send-keys -t %s -- "%s" Enter', flag, M.__target_socket, M.__target_pane,
+		text)
 	vim.fn.systemlist(cmd)
 end
 


### PR DESCRIPTION
Due to popular demand (and to make this actually work after I kind of threw this feature at the wall when originally setting up this plugin), this PR adds the ability to escape input sent via tmux send-keys with an array of strings that are all used to escape before sending. This can be set up as part of the plugin init or later on, and comes with sensible defaults if you'd prefer to just have it work out of the box. Will spend a bit more time running through test cases before merging, may add a file with some basic cases to check against for the future if something ends up sneaking through.

Thanks so much to @m-faith and @abelier for bringing this to my attention!